### PR TITLE
Update example to use local argument

### DIFF
--- a/tf-distribution-options/code/train_ps.py
+++ b/tf-distribution-options/code/train_ps.py
@@ -47,9 +47,8 @@ def save_history(path, history):
 def save_model(model, output):
 
     # create a TensorFlow SavedModel for deployment to a SageMaker endpoint with TensorFlow Serving
-    tf.contrib.saved_model.save_keras_model(model, args.model_dir)
+    tf.contrib.saved_model.save_keras_model(model, output)
     logging.info("Model successfully saved at: {}".format(output))
-    return
 
 
 def main(args):


### PR DESCRIPTION
*Issue #5*

[A function from example script](https://github.com/aws-samples/amazon-sagemaker-script-mode/blob/e68b209fa3c3e286df72ec839addc26bb4988526/tf-distribution-options/code/train_ps.py#L50) doesn't use local variable `output` as a location to save trained SageMaker model and refers to the global state instead.

*Description of changes:*

The function was adjusted to use the provided parameter and doesn't use `args` global state.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.