### PR TITLE
Deploy pretrained model using built in containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Amazon SageMaker Script Mode Examples
 
-This repository contains examples and related resources regarding Amazon SageMaker Script Mode and SageMaker Processing. With Script Mode, you can use training scripts similar to those you would use outside SageMaker with SageMaker's prebuilt containers for various deep learning frameworks such TensorFlow, PyTorch, and Apache MXNet.  Similarly, in SageMaker Processing, you can supply ordinary data preprocessing scripts for almost any language or technology you wish to use, such as the R programming language.  
+This repository contains examples and related resources regarding Amazon SageMaker Script Mode and SageMaker Processing. With Script Mode, you can use training scripts similar to those you would use outside SageMaker with SageMaker's prebuilt containers for various frameworks such TensorFlow, PyTorch, and Apache MXNet.  Similarly, in SageMaker Processing, you can supply ordinary data preprocessing scripts for almost any language or technology you wish to use, such as the R programming language.  
 
 Currently this repository has the following resources:
 
@@ -14,25 +14,24 @@ Currently this repository has the following resources:
 
   - [**TensorFlow Highly Performant Batch Inference & Training**](tf-batch-inference-script):  The focus of this example is highly performant batch inference using TensorFlow Serving, along with Horovod distributed training. To transform the input image data for inference, a preprocessing script is used with the Amazon SageMaker TensorFlow Serving container.  **PREREQUISITES:**  be sure to upload all files in the *tf-batch-inference-script* directory (including the subdirectory code and files) to the directory where you will run the related Jupyter notebook.  
 
-  - [**TensorFlow Text Classification with Word Embeddings**](tf-word-embeddings): In this example, TensorFlow's tf.keras API is used with Script Mode for a text classification task. An important aspect of the example is showing how to load preexisting word embeddings such as GloVe in Script Mode.  Other features demonstrated include Local Mode endpoints as well as Local Mode training. **PREREQUISITES:**  (1) Use a GPU-based (P3 or P2) SageMaker notebook instance, and (2) be sure to upload all files in the *tf-word-embeddings* directory (including subdirectory *code*) to the directory where you will run the related Jupyter notebook. 
+  - [**TensorFlow Text Classification with Word Embeddings**](tf-word-embeddings): In this example, TensorFlow's tf.keras API is used with Script Mode for a text classification task. An important aspect of the example is showing how to load preexisting word embeddings such as GloVe in Script Mode.  Other features demonstrated include Local Mode endpoints as well as Local Mode training. **PREREQUISITES:**  (1) Use a GPU-based (P3 or P2) SageMaker notebook instance, and (2) be sure to upload all files in the *tf-word-embeddings* directory (including subdirectory *code*) to the directory where you will run the related Jupyter notebook.
 
   - [**TensorFlow with Horovod & Inference Pipeline**](tf-horovod-inference-pipeline):  Script Mode with TensorFlow is used for a computer vision task, in a demonstration of Horovod distributed training and doing batch inference in conjunction with an Inference Pipeline for transforming image data before inputting it to the model container. This is an alternative to the previous example, which uses a preprocessing script with the Amazon SageMaker TensorFlow Serving Container rather than an Inference Pipeline. **PREREQUISITES:**  be sure to upload all files in the *tf-horovod-inference-pipeline* directory (including the subdirectory code and files) to the directory where you will run the related Jupyter notebook.  
 
   - [**TensorFlow Eager Execution**](tf-eager-script-mode):  NOTE:  This example has been superseded by the **TensorFlow 2 Workflow** example above.  This example shows how to use Script Mode with Eager Execution mode in TensorFlow 1.x, a more intuitive and dynamic alternative to the original graph mode of TensorFlow.  It is the default mode of TensorFlow 2.  Local Mode and Automatic Model Tuning also are demonstrated. **PREREQUISITES:**  From the *tf-eager-script-mode* directory, upload ONLY the Jupyter notebook `tf-boston-housing.ipynb`.  
 
 
-- **R resources:**  
-
-  - [**R in SageMaker Processing**](r-in-sagemaker-processing): In this example, R is used to perform some operations on a dataset and generate a plot within SageMaker Processing.  The job results including the plot image are retrieved and displayed, demonstrating how R can be easily used within a SageMaker workflow. **PREREQUISITES:**  From the *r-in-sagemaker-processing* directory, upload the Jupyter notebook `r-in-sagemaker_processing.ipynb`.
-  
-
-
 - **Miscellaneous resources:**  
 
   - [**K-means clustering**](k-means-clustering): Most of the samples in this repository involve supervised learning tasks in Amazon SageMaker Script Mode.  For this example, by contrast, we'll undertake an unsupervised learning task, and do so with the Amazon SageMaker K-means built-in algorithm rather than Script Mode.  **PREREQUISITES:**  From the *k-means-clustering* directory, upload the Jupyter notebook `k-means-clustering.ipynb`.
-  
+
+  - [**lightGBM BYO**](lightgbm-byo): In this repository, most samples use Amazon SageMaker prebuilt framework containers for TensorFlow and other frameworks.  For this example, however, we'll show how to BYO container similar to a prebuilt SageMaker framework container, using lightGBM, a popular gradient boosting framework.  **PREREQUISITES:**  From the *lightgbm-byo* directory, upload the Jupyter notebook `lightgbm-byo.ipynb`.
+
+  - [**R in SageMaker Processing**](r-in-sagemaker-processing): In this example, R is used to perform some operations on a dataset and generate a plot within SageMaker Processing.  The job results including the plot image are retrieved and displayed, demonstrating how R can be easily used within a SageMaker workflow. **PREREQUISITES:**  From the *r-in-sagemaker-processing* directory, upload the Jupyter notebook `r-in-sagemaker_processing.ipynb`.
+
+  - [**Deploy Pretrained Models**](deploy-pretrained-model):  SageMaker's prebuilt PyTorch container is used to demonstrate how you can quickly take a pretrained or locally trained model and deploy them as SageMaker hosted API endpoints. There are examples for both OpenAI's GPT-2 and BERT. **PREREQUISITES:**  From the *deploy-pretrained-model* directory, upload the entire BERT or GPT2 folder's contents, depending on which model you select. Run either `Deploy_BERT.pynb` or `Deploy_GPT2.ipynb`.  
 
 
 ## License
 
-The contents of this repository are licensed under the Apache 2.0 License except where otherwise noted. 
+The contents of this repository are licensed under the Apache 2.0 License except where otherwise noted.

--- a/deploy-pretrained-model/BERT/Deploy_BERT.ipynb
+++ b/deploy-pretrained-model/BERT/Deploy_BERT.ipynb
@@ -1,0 +1,198 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Hosting a Pretrained Model on SageMaker\n",
+    "    \n",
+    "Amazon SageMaker is a service to accelerate the entire machine learning lifecycle. It includes components for building, training and deploying machine learning models. Each SageMaker component is modular, so you're welcome to only use the features needed for your use case. One of the most popular features of SageMaker is [model hosting](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-deployment.html). Using SageMaker Hosting you can deploy your model as a scalable, highly available, multi-threaded API endpoint with a few lines of code. In this notebook, we will demonstrate how to host a pretrained model (BERT) in Amazon SageMaker.\n",
+    "\n",
+    "SageMaker provides prebuilt containers that can be used for training, hosting, or data processing. The inference containers include a web serving stack, so you don't need to install and configure one. We will be using the SageMaker [PyTorch container](https://github.com/aws/deep-learning-containers), but you may use the [TensorFlow container](https://github.com/aws/deep-learning-containers/blob/master/available_images.md), or bring your own container if needed.  \n",
+    "\n",
+    "This notebook will walk you through how to deploy a pretrained Hugging Face model as a scalable, highly available, production ready API in under 15 minutes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Retrieve Model Artifacts\n",
+    "\n",
+    "First we will download the model artifacts for the pretrained [BERT](https://arxiv.org/abs/1810.04805) model. BERT is a popular natural language processing (NLP) model that extracts meaning and context from text."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "!pip install transformers==3.3.1 sagemaker==2.15.0 --quiet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from transformers import BertTokenizer, BertModel\n",
+    "\n",
+    "tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')\n",
+    "model = BertModel.from_pretrained(\"bert-base-uncased\")\n",
+    "\n",
+    "model_path = 'model/'\n",
+    "code_path = 'code/'\n",
+    "\n",
+    "if not os.path.exists(model_path):\n",
+    "    os.mkdir(model_path)\n",
+    "    \n",
+    "model.save_pretrained(save_directory=model_path)\n",
+    "tokenizer.save_pretrained(save_directory=model_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Write the Inference Script\n",
+    "\n",
+    "Since we are bringing a model to SageMaker, we must create an inference script. The script will run inside our PyTorch container. Our script should include a function for model loading, and optionally functions generating predicitions, and input/output processing. The PyTorch container provides default implementations for generating a prediction and input/output processing. By including these functions in your script you are overriding the default functions. You can find additional [details here](https://sagemaker.readthedocs.io/en/stable/frameworks/pytorch/using_pytorch.html#serve-a-pytorch-model).\n",
+    "\n",
+    "In the next cell we'll see our inference script. You will notice that it uses the [transformers library from HuggingFace](https://huggingface.co/transformers/). This Python library is not installed in the container by default, so we will have to add that in the next section."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pygmentize code/inference_code.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Package Model\n",
+    "\n",
+    "For hosting, SageMaker requires that the deployment package be structed in a compatible format. It expects all files to be packaged in a tar archive named \"model.tar.gz\" with gzip compression. To install additional libraries at container startup, we can add a [requirements.txt](https://sagemaker.readthedocs.io/en/stable/frameworks/pytorch/using_pytorch.html#using-third-party-libraries) text file that specifies the libraries to be installed using [pip](https://pypi.org/project/pip/). Within the archive, the PyTorch container expects all inference code and requirements.txt file to be inside the code/ directory. See the [guide here](https://sagemaker.readthedocs.io/en/stable/frameworks/pytorch/using_pytorch.html#for-versions-1-2-and-higher) for a thorough explanation of the required directory structure.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tarfile\n",
+    "\n",
+    "zipped_model_path = os.path.join(model_path, \"model.tar.gz\")\n",
+    "\n",
+    "with tarfile.open(zipped_model_path, \"w:gz\") as tar:\n",
+    "    tar.add(model_path)\n",
+    "    tar.add(code_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Deploy Model\n",
+    "\n",
+    "Now that we have our deployment package, we can use the [SageMaker SDK](https://sagemaker.readthedocs.io/en/stable/index.html) to deploy our API endpoint with two lines of code. We need to specify an IAM role for the SageMaker endpoint to use. Minimally, it will need read access to the default SageMaker bucket (usually named sagemaker-{region}-{your account number}) so it can read the deployment package. When we call deploy(), the SDK will save our deployment archive to S3 for the SageMaker endpoint to use. We will use the helper function [get_execution_role](https://sagemaker.readthedocs.io/en/stable/api/utility/session.html?highlight=get_execution_role#sagemaker.session.get_execution_role) to retrieve our current IAM role so we can pass it to the SageMaker endpoint. \n",
+    "\n",
+    "You may notice that we specify our PyTorch version and Python version when creating the PyTorchModel object. The SageMaker SDK uses these parameters to determine which PyTorch container to use. \n",
+    "\n",
+    "We'll choose an m5 instance for our endpoint to ensure we have sufficient memory to serve our model. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.pytorch import PyTorchModel\n",
+    "from sagemaker import get_execution_role\n",
+    "\n",
+    "endpoint_name = 'bert-base-test-11-4'\n",
+    "\n",
+    "model = PyTorchModel(entry_point='inference_code.py', \n",
+    "                     model_data=zipped_model_path, \n",
+    "                     role=get_execution_role(), \n",
+    "                     framework_version='1.5', \n",
+    "                     py_version='py3')\n",
+    "\n",
+    "predictor = model.deploy(initial_instance_count=1, \n",
+    "                         instance_type='ml.m5.xlarge', \n",
+    "                         endpoint_name=endpoint_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get Predictions\n",
+    "\n",
+    "Now that our API endpoint is deployed, we can send it text to get predictions from our BERT model. You can use the SageMaker SDK or the [SageMaker Runtime API](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_runtime_InvokeEndpoint.html) to invoke the endpoint. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "\n",
+    "sm = boto3.client('sagemaker-runtime')\n",
+    "\n",
+    "prompt = \"The best part of Amazon SageMaker is that it makes machine learning easy.\"\n",
+    "\n",
+    "response = sm.invoke_endpoint(EndpointName=endpoint_name, \n",
+    "                              Body=prompt.encode(encoding='UTF-8'),\n",
+    "                              ContentType='text/csv')\n",
+    "\n",
+    "response['Body'].read()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "You have successfully created a scalable, high available, RESTful API that is backed by a BERT model! If you are still interested in learning more, check out some of the more advanced features of SageMaker Hosting, like [model monitoring](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to detect concept drift, [autoscaling](https://docs.aws.amazon.com/sagemaker/latest/dg/endpoint-auto-scaling.html) to dynamically adjust the number of instances, or [VPC config](https://docs.aws.amazon.com/sagemaker/latest/dg/host-vpc.html) to control network access to/from your endpoint.\n",
+    "\n",
+    "You can also look in to the [ezsmdeploy SDK](https://aws.amazon.com/blogs/opensource/deploy-machine-learning-models-to-amazon-sagemaker-using-the-ezsmdeploy-python-package-and-a-few-lines-of-code/) that automates most of this process."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "conda_pytorch_latest_p36",
+   "language": "python",
+   "name": "conda_pytorch_latest_p36"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/deploy-pretrained-model/BERT/Deploy_BERT.ipynb
+++ b/deploy-pretrained-model/BERT/Deploy_BERT.ipynb
@@ -105,7 +105,8 @@
    "source": [
     "## Deploy Model\n",
     "\n",
-    "Now that we have our deployment package, we can use the [SageMaker SDK](https://sagemaker.readthedocs.io/en/stable/index.html) to deploy our API endpoint with two lines of code. We need to specify an IAM role for the SageMaker endpoint to use. Minimally, it will need read access to the default SageMaker bucket (usually named sagemaker-{region}-{your account number}) so it can read the deployment package. When we call deploy(), the SDK will save our deployment archive to S3 for the SageMaker endpoint to use. We will use the helper function [get_execution_role](https://sagemaker.readthedocs.io/en/stable/api/utility/session.html?highlight=get_execution_role#sagemaker.session.get_execution_role) to retrieve our current IAM role so we can pass it to the SageMaker endpoint. \n",
+    "Now that we have our deployment package, we can use the [SageMaker SDK](https://sagemaker.readthedocs.io/en/stable/index.html) to deploy our API endpoint with two lines of code. We need to specify an IAM role for the SageMaker endpoint to use. Minimally, it will need read access to the default SageMaker bucket (usually named sagemaker-{region}-{your account number}) so it can read the deployment package. When we call deploy(), the SDK will save our deployment archive to S3 for the SageMaker endpoint to use. We will use the helper function [get_execution_role](https://sagemaker.readthedocs.io/en/stable/api/utility/session.html?highlight=get_execution_role#sagemaker.session.get_execution_role) to retrieve our current IAM role so we can pass it to the SageMaker endpoint. Minimally it will require read access to the model artifacts in S3 and the [ECR repository](https://github.com/aws/deep-learning-containers/blob/master/available_images.md) where the container image is stored by AWS.\n",
+    "\n",
     "\n",
     "You may notice that we specify our PyTorch version and Python version when creating the PyTorchModel object. The SageMaker SDK uses these parameters to determine which PyTorch container to use. \n",
     "\n",
@@ -121,7 +122,7 @@
     "from sagemaker.pytorch import PyTorchModel\n",
     "from sagemaker import get_execution_role\n",
     "\n",
-    "endpoint_name = 'bert-base-test-11-4'\n",
+    "endpoint_name = 'bert-base'\n",
     "\n",
     "model = PyTorchModel(entry_point='inference_code.py', \n",
     "                     model_data=zipped_model_path, \n",

--- a/deploy-pretrained-model/BERT/Deploy_BERT.ipynb
+++ b/deploy-pretrained-model/BERT/Deploy_BERT.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "## Hosting a Pretrained Model on SageMaker\n",
     "    \n",
-    "Amazon SageMaker is a service to accelerate the entire machine learning lifecycle. It includes components for building, training and deploying machine learning models. Each SageMaker component is modular, so you're welcome to only use the features needed for your use case. One of the most popular features of SageMaker is [model hosting](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-deployment.html). Using SageMaker Hosting you can deploy your model as a scalable, highly available, multi-threaded API endpoint with a few lines of code. In this notebook, we will demonstrate how to host a pretrained model (BERT) in Amazon SageMaker.\n",
+    "Amazon SageMaker is a service to accelerate the entire machine learning lifecycle. It includes components for building, training and deploying machine learning models. Each SageMaker component is modular, so you're welcome to only use the features needed for your use case. One of the most popular features of SageMaker is [model hosting](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-deployment.html). Using SageMaker Hosting you can deploy your model as a scalable, highly available, multi-process API endpoint with a few lines of code. In this notebook, we will demonstrate how to host a pretrained model (BERT) in Amazon SageMaker to extract embeddings from text.\n",
     "\n",
     "SageMaker provides prebuilt containers that can be used for training, hosting, or data processing. The inference containers include a web serving stack, so you don't need to install and configure one. We will be using the SageMaker [PyTorch container](https://github.com/aws/deep-learning-containers), but you may use the [TensorFlow container](https://github.com/aws/deep-learning-containers/blob/master/available_images.md), or bring your own container if needed.  \n",
     "\n",
@@ -169,10 +169,17 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "You have successfully created a scalable, high available, RESTful API that is backed by a BERT model! If you are still interested in learning more, check out some of the more advanced features of SageMaker Hosting, like [model monitoring](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to detect concept drift, [autoscaling](https://docs.aws.amazon.com/sagemaker/latest/dg/endpoint-auto-scaling.html) to dynamically adjust the number of instances, or [VPC config](https://docs.aws.amazon.com/sagemaker/latest/dg/host-vpc.html) to control network access to/from your endpoint.\n",
+    "You have successfully created a scalable, high available, RESTful API that is backed by a BERT model! It can be used for downstreaming NLP tasks like text classification. If you are still interested in learning more, check out some of the more advanced features of SageMaker Hosting, like [model monitoring](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to detect concept drift, [autoscaling](https://docs.aws.amazon.com/sagemaker/latest/dg/endpoint-auto-scaling.html) to dynamically adjust the number of instances, or [VPC config](https://docs.aws.amazon.com/sagemaker/latest/dg/host-vpc.html) to control network access to/from your endpoint.\n",
     "\n",
     "You can also look in to the [ezsmdeploy SDK](https://aws.amazon.com/blogs/opensource/deploy-machine-learning-models-to-amazon-sagemaker-using-the-ezsmdeploy-python-package-and-a-few-lines-of-code/) that automates most of this process."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/deploy-pretrained-model/BERT/code/inference_code.py
+++ b/deploy-pretrained-model/BERT/code/inference_code.py
@@ -1,0 +1,56 @@
+import os
+import json
+from transformers import BertTokenizer, BertModel
+
+def model_fn(model_dir):
+    """
+    Load the model for inference
+    """
+
+    model_path = os.path.join(model_dir, 'model/')
+    
+    # Load BERT tokenizer from disk.
+    tokenizer = BertTokenizer.from_pretrained(model_path)
+
+    # Load BERT model from disk.
+    model = BertModel.from_pretrained(model_path)
+
+    model_dict = {'model': model, 'tokenizer':tokenizer}
+    
+    return model_dict
+
+def predict_fn(input_data, model):
+    """
+    Apply model to the incoming request
+    """
+    
+    tokenizer = model['tokenizer']
+    bert_model = model['model']
+    
+    encoded_input = tokenizer(input_data, return_tensors='pt')
+    
+    return bert_model(**encoded_input)
+
+def input_fn(request_body, request_content_type):
+    """
+    Deserialize and prepare the prediction input
+    """
+    
+    if request_content_type == "application/json":
+        request = json.loads(request_body)
+    else:
+        request = request_body
+
+    return request
+
+def output_fn(prediction, response_content_type):
+    """
+    Serialize and prepare the prediction output
+    """
+    
+    if response_content_type == "application/json":
+        response = str(prediction)
+    else:
+        response = str(prediction)
+
+    return response

--- a/deploy-pretrained-model/BERT/code/requirements.txt
+++ b/deploy-pretrained-model/BERT/code/requirements.txt
@@ -1,0 +1,1 @@
+transformers==3.3.1

--- a/deploy-pretrained-model/GPT2/Deploy_GPT2.ipynb
+++ b/deploy-pretrained-model/GPT2/Deploy_GPT2.ipynb
@@ -105,7 +105,7 @@
    "source": [
     "## Deploy Model\n",
     "\n",
-    "Now that we have our deployment package, we can use the [SageMaker SDK](https://sagemaker.readthedocs.io/en/stable/index.html) to deploy our API endpoint with two lines of code. We need to specify an IAM role for the SageMaker endpoint to use. Minimally, it will need read access to the default SageMaker bucket (usually named sagemaker-{region}-{your account number}) so it can read the deployment package. When we call deploy(), the SDK will save our deployment archive to S3 for the SageMaker endpoint to use. We will use the helper function [get_execution_role](https://sagemaker.readthedocs.io/en/stable/api/utility/session.html?highlight=get_execution_role#sagemaker.session.get_execution_role) to retrieve our current IAM role so we can pass it to the SageMaker endpoint. \n",
+    "Now that we have our deployment package, we can use the [SageMaker SDK](https://sagemaker.readthedocs.io/en/stable/index.html) to deploy our API endpoint with two lines of code. We need to specify an IAM role for the SageMaker endpoint to use. Minimally, it will need read access to the default SageMaker bucket (usually named sagemaker-{region}-{your account number}) so it can read the deployment package. When we call deploy(), the SDK will save our deployment archive to S3 for the SageMaker endpoint to use. We will use the helper function [get_execution_role](https://sagemaker.readthedocs.io/en/stable/api/utility/session.html?highlight=get_execution_role#sagemaker.session.get_execution_role) to retrieve our current IAM role so we can pass it to the SageMaker endpoint. You may specify another IAM role here. Minimally it will require read access to the model artifacts in S3 and the [ECR repository](https://github.com/aws/deep-learning-containers/blob/master/available_images.md) where the container image is stored by AWS.\n",
     "\n",
     "You may notice that we specify our PyTorch version and Python version when creating the PyTorchModel object. The SageMaker SDK uses these parameters to determine which PyTorch container to use. \n",
     "\n",
@@ -121,7 +121,7 @@
     "from sagemaker.pytorch import PyTorchModel\n",
     "from sagemaker import get_execution_role\n",
     "\n",
-    "endpoint_name = 'GPT2-11-3-test'\n",
+    "endpoint_name = 'GPT2'\n",
     "\n",
     "model = PyTorchModel(entry_point='inference_code.py', \n",
     "                     model_data=zipped_model_path, \n",

--- a/deploy-pretrained-model/GPT2/Deploy_GPT2.ipynb
+++ b/deploy-pretrained-model/GPT2/Deploy_GPT2.ipynb
@@ -1,0 +1,199 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Hosting a Pretrained Model on SageMaker\n",
+    "    \n",
+    "Amazon SageMaker is a service to accelerate the entire machine learning lifecycle. It includes components for building, training and deploying machine learning models. Each SageMaker component is modular, so you're welcome to only use the features needed for your use case. One of the most popular features of SageMaker is [model hosting](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-deployment.html). Using SageMaker Hosting you can deploy your model as a scalable, highly available, multi-process API endpoint with a few lines of code. In this notebook, we will demonstrate how to host a pretrained model (GPT-2) in Amazon SageMaker.\n",
+    "\n",
+    "SageMaker provides prebuilt containers that can be used for training, hosting, or data processing. The inference containers include a web serving stack, so you don't need to install and configure one. We will be using the SageMaker [PyTorch container](https://github.com/aws/deep-learning-containers), but you may use the [TensorFlow container](https://github.com/aws/deep-learning-containers/blob/master/available_images.md), or bring your own container if needed.  \n",
+    "\n",
+    "This notebook will walk you through how to deploy a pretrained Hugging Face model as a scalable, highly available, production ready API in under 15 minutes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Retrieve Model Artifacts\n",
+    "\n",
+    "First we will download the model artifacts for the pretrained [GPT-2](https://d4mucfpksywv.cloudfront.net/better-language-models/language_models_are_unsupervised_multitask_learners.pdf) model. GPT-2 is a popular text generation model that was developed by OpenAI. Given a text prompt it can generate synthetic text that may follow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "!pip install transformers==3.3.1 sagemaker==2.15.0 --quiet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from transformers import GPT2Tokenizer, GPT2LMHeadModel\n",
+    "\n",
+    "tokenizer = GPT2Tokenizer.from_pretrained('gpt2')\n",
+    "model = GPT2LMHeadModel.from_pretrained('gpt2')\n",
+    "\n",
+    "model_path = 'model/'\n",
+    "code_path = 'code/'\n",
+    "\n",
+    "if not os.path.exists(model_path):\n",
+    "    os.mkdir(model_path)\n",
+    "    \n",
+    "model.save_pretrained(save_directory=model_path)\n",
+    "tokenizer.save_vocabulary(save_directory=model_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Write the Inference Script\n",
+    "\n",
+    "Since we are bringing a model to SageMaker, we must create an inference script. The script will run inside our PyTorch container. Our script should include a function for model loading, and optionally functions generating predicitions, and input/output processing. The PyTorch container provides default implementations for generating a prediction and input/output processing. By including these functions in your script you are overriding the default functions. You can find additional [details here](https://sagemaker.readthedocs.io/en/stable/frameworks/pytorch/using_pytorch.html#serve-a-pytorch-model).\n",
+    "\n",
+    "In the next cell we'll see our inference script. You will notice that it uses the [transformers library from Hugging Face](https://huggingface.co/transformers/). This Python library is not installed in the container by default, so we will have to add that in the next section."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pygmentize code/inference_code.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Package Model\n",
+    "\n",
+    "For hosting, SageMaker requires that the deployment package be structed in a compatible format. It expects all files to be packaged in a tar archive named \"model.tar.gz\" with gzip compression. To install additional libraries at container startup, we can add a [requirements.txt](https://sagemaker.readthedocs.io/en/stable/frameworks/pytorch/using_pytorch.html#using-third-party-libraries) text file that specifies the libraries to be installed using [pip](https://pypi.org/project/pip/). Within the archive, the PyTorch container expects all inference code and requirements.txt file to be inside the code/ directory. See the [guide here](https://sagemaker.readthedocs.io/en/stable/frameworks/pytorch/using_pytorch.html#for-versions-1-2-and-higher) for a thorough explanation of the required directory structure.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tarfile\n",
+    "\n",
+    "zipped_model_path = os.path.join(model_path, \"model.tar.gz\")\n",
+    "\n",
+    "with tarfile.open(zipped_model_path, \"w:gz\") as tar:\n",
+    "    tar.add(model_path)\n",
+    "    tar.add(code_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Deploy Model\n",
+    "\n",
+    "Now that we have our deployment package, we can use the [SageMaker SDK](https://sagemaker.readthedocs.io/en/stable/index.html) to deploy our API endpoint with two lines of code. We need to specify an IAM role for the SageMaker endpoint to use. Minimally, it will need read access to the default SageMaker bucket (usually named sagemaker-{region}-{your account number}) so it can read the deployment package. When we call deploy(), the SDK will save our deployment archive to S3 for the SageMaker endpoint to use. We will use the helper function [get_execution_role](https://sagemaker.readthedocs.io/en/stable/api/utility/session.html?highlight=get_execution_role#sagemaker.session.get_execution_role) to retrieve our current IAM role so we can pass it to the SageMaker endpoint. \n",
+    "\n",
+    "You may notice that we specify our PyTorch version and Python version when creating the PyTorchModel object. The SageMaker SDK uses these parameters to determine which PyTorch container to use. \n",
+    "\n",
+    "The full size [GPT-2 model has 1.2 billion parameters](https://d4mucfpksywv.cloudfront.net/better-language-models/language_models_are_unsupervised_multitask_learners.pdf). Even though we are using the small version of the model, our endpoint will need to fit millions of parameters in to memory. We'll choose an m5 instance for our endpoint to ensure we have sufficient memory to serve our model. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.pytorch import PyTorchModel\n",
+    "from sagemaker import get_execution_role\n",
+    "\n",
+    "endpoint_name = 'GPT2-11-3-test'\n",
+    "\n",
+    "model = PyTorchModel(entry_point='inference_code.py', \n",
+    "                     model_data=zipped_model_path, \n",
+    "                     role=get_execution_role(),\n",
+    "                     framework_version='1.5', \n",
+    "                     py_version='py3')\n",
+    "\n",
+    "predictor = model.deploy(initial_instance_count=1, \n",
+    "                         instance_type='ml.m5.xlarge', \n",
+    "                         endpoint_name=endpoint_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get Predictions\n",
+    "\n",
+    "Now that our RESTful API endpoint is deployed, we can send it text to get predictions from our GPT-2 model. You can use the SageMaker Python SDK or the [SageMaker Runtime API](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_runtime_InvokeEndpoint.html) to invoke the endpoint. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "import json\n",
+    "\n",
+    "sm = boto3.client('sagemaker-runtime')\n",
+    "\n",
+    "prompt = \"Working with SageMaker makes machine learning \"\n",
+    "\n",
+    "response = sm.invoke_endpoint(EndpointName=endpoint_name, \n",
+    "                              Body=json.dumps(prompt),\n",
+    "                              ContentType='text/csv')\n",
+    "\n",
+    "response['Body'].read().decode('utf-8')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "You have successfully created a scalable, high available, RESTful API that is backed by a GPT-2 model! If you are still interested in learning more, check out some of the more advanced features of SageMaker Hosting, like [model monitoring](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to detect concept drift, [autoscaling](https://docs.aws.amazon.com/sagemaker/latest/dg/endpoint-auto-scaling.html) to dynamically adjust the number of instances, or [VPC config](https://docs.aws.amazon.com/sagemaker/latest/dg/host-vpc.html) to control network access to/from your endpoint.\n",
+    "\n",
+    "You can also look in to the [ezsmdeploy SDK](https://aws.amazon.com/blogs/opensource/deploy-machine-learning-models-to-amazon-sagemaker-using-the-ezsmdeploy-python-package-and-a-few-lines-of-code/) that automates most of this process."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "conda_pytorch_latest_p36",
+   "language": "python",
+   "name": "conda_pytorch_latest_p36"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/deploy-pretrained-model/GPT2/code/inference_code.py
+++ b/deploy-pretrained-model/GPT2/code/inference_code.py
@@ -1,0 +1,47 @@
+import os
+import json
+from transformers import GPT2Tokenizer, TextGenerationPipeline, GPT2LMHeadModel
+
+def model_fn(model_dir):
+    """
+    Load the model for inference
+    """
+
+    # Load GPT2 tokenizer from disk.
+    vocab_path = os.path.join(model_dir, 'model/vocab.json')
+    merges_path = os.path.join(model_dir, 'model/merges.txt')
+    
+    tokenizer = GPT2Tokenizer(vocab_file=vocab_path,
+                              merges_file=merges_path)
+
+    # Load GPT2 model from disk.
+    model_path = os.path.join(model_dir, 'model/')
+    model = GPT2LMHeadModel.from_pretrained(model_path)
+
+    return TextGenerationPipeline(model=model, tokenizer=tokenizer)
+
+def predict_fn(input_data, model):
+    """
+    Apply model to the incoming request
+    """
+
+    return model.__call__(input_data)
+
+def input_fn(request_body, request_content_type):
+    """
+    Deserialize and prepare the prediction input
+    """
+    
+    if request_content_type == "application/json":
+        request = json.loads(request_body)
+    else:
+        request = request_body
+
+    return request
+
+def output_fn(prediction, response_content_type):
+    """
+    Serialize and prepare the prediction output
+    """
+
+    return str(prediction)

--- a/deploy-pretrained-model/GPT2/code/requirements.txt
+++ b/deploy-pretrained-model/GPT2/code/requirements.txt
@@ -1,0 +1,1 @@
+transformers==3.3.1


### PR DESCRIPTION
*Description of changes:*
 I added two notebooks that download popular pretrained models and deploy them as SageMaker endpoints. The intention is to show how you can deploy pretrained or locally trained models on SageMaker. Most of our examples show the entire training, deployment process. This focuses on modularity. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
